### PR TITLE
Revert bool fields to yes/no

### DIFF
--- a/policies/schema.yml
+++ b/policies/schema.yml
@@ -55,7 +55,8 @@ mapping:
     type: str
     desc: "Journal’s policy about co-reviewers - ie people who collaborate with an invited reviewer (free text)"
   co-review-invited:
-    type: bool
+    type: str
+    enum: [yes, no]
     desc: "Does the journal make it clear in the reviewer invitation email that co-reviewers can contribute? (yes/no)"
 
   # PEER REVIEW TRANSFER
@@ -76,10 +77,12 @@ mapping:
     type: str
     desc: "What are the titles of the sections of the review form? (free text)"
   separate-structure:
-    type: bool
+    type: str
+    enum: [yes, no]
     desc: Are there separate fields for technical & impact evaluation? (yes/no)
   co-review-field:
-    type: bool
+    type: str
+    enum: [yes, no]
     desc: "Is there a dedicated place in the submission form to identify co-reviewers? (yes/no)"
 
   # PEER REVIEW CREDIT
@@ -125,7 +128,8 @@ mapping:
     enum: [before acceptance only, anytime, other]
     desc: Time when a preprint can be posted (before acceptance only, anytime, other)
   preprint-citation:
-    type: bool
+    type: str
+    enum: [yes, no]
     desc: "Can preprints be cited in the reference list? (yes/no)"
   acceptable-servers:
     type: str


### PR DESCRIPTION
This reverts commit c1a87e67d3a59956057c7a584d36e03f685cbe01.

YAML 1.2 only accepts true/false for bool fields
http://yaml.org/spec/1.2/spec.html#id2803629

However, we thought yes/no is more intuitive