### PR TITLE
adds link to general guideline

### DIFF
--- a/policies/policies/romeo_1140.yml
+++ b/policies/policies/romeo_1140.yml
@@ -1019,10 +1019,10 @@ child-policies: []
 flag-romeo:
 
 # Peer review policy url (valid url)
-peer-review-url:
+peer-review-url: https://authorservices.taylorandfrancis.com/category/understanding-peer-review/
 
 # Does the journal publish the content of peer reviews? (mandatory/optional/no)
-open-reports:
+open-reports: 
 
 # Are reviewer identities revealed to the author? (mandatory/optional/no)
 identities-revealed:


### PR DESCRIPTION
The guide for authors is general and states that policies are set on a per-journal basis.